### PR TITLE
Fixed threading issue in CancelConnectionAttempt.

### DIFF
--- a/Source/RakPeer.h
+++ b/Source/RakPeer.h
@@ -713,6 +713,7 @@ protected:
 	// Two versions needed because some buggy compilers strip the last parameter if unused, and crashes
 	ConnectionAttemptResult SendConnectionRequest( const char* host, unsigned short remotePort, const char *passwordData, int passwordDataLength, PublicKey *publicKey, unsigned connectionSocketIndex, unsigned int extraData, unsigned sendConnectionAttemptCount, unsigned timeBetweenSendConnectionAttemptsMS, RakNet::TimeMS timeoutTime, RakNetSocket2* socket );
 	ConnectionAttemptResult SendConnectionRequest( const char* host, unsigned short remotePort, const char *passwordData, int passwordDataLength, PublicKey *publicKey, unsigned connectionSocketIndex, unsigned int extraData, unsigned sendConnectionAttemptCount, unsigned timeBetweenSendConnectionAttemptsMS, RakNet::TimeMS timeoutTime );
+	void HandleConnectionCancelQueue( );
 	///Get the reliability layer associated with a systemAddress.  
 	/// \param[in] systemAddress The player identifier 
 	/// \return 0 if none
@@ -864,7 +865,9 @@ protected:
 	DataStructures::List<PluginInterface2*> pluginListTS, pluginListNTS;
 
 	DataStructures::Queue<RequestedConnectionStruct*> requestedConnectionQueue;
+	DataStructures::Queue<SystemAddress> requestedConnectionCancelQueue;
 	SimpleMutex requestedConnectionQueueMutex;
+	SimpleMutex requestedConnectionCancelQueueMutex;
 
 	// void RunMutexedUpdateCycle(void);
 


### PR DESCRIPTION
A mutex is locked when getting entries in requestedConnectionQueue, but these entries are then manipulated outside of the locked area. When calling CancelConnectionAttempt these entries can be removed while still being manipulated causing all kinds of corruptions and crashes. This is now fixed by queuing the canceling of connection attempts.
