### PR TITLE
Removes deprecation build warning

### DIFF
--- a/Source/NatPunchthroughClient.cpp
+++ b/Source/NatPunchthroughClient.cpp
@@ -792,7 +792,7 @@ void NatPunchthroughClient::SendTTL(const SystemAddress &sa)
 	rakPeerInterface->SendTTL(ipAddressString,sa.GetPort(), 2);
 }
 
-char *TestModeToString(NatPunchthroughClient::SendPing::TestMode tm)
+const char *TestModeToString(NatPunchthroughClient::SendPing::TestMode tm)
 {
 	switch (tm)
 	{


### PR DESCRIPTION
Changing the return type form char\* to const char\* removes a build
warnings: “NatPunchthroughClient.cpp:800:11: Conversion from string
literal to 'char *' is deprecated”

Only tested on Mac Xcode 5.1.1 and a gcc compile running on Android
(targeting 2.3 API level 10)
