### PR TITLE
Change TestModeToString so it returns a const ptr

### DIFF
--- a/Source/NatPunchthroughClient.cpp
+++ b/Source/NatPunchthroughClient.cpp
@@ -792,7 +792,7 @@ void NatPunchthroughClient::SendTTL(const SystemAddress &sa)
 	rakPeerInterface->SendTTL(ipAddressString,sa.GetPort(), 2);
 }
 
-char *TestModeToString(NatPunchthroughClient::SendPing::TestMode tm)
+const char *TestModeToString(NatPunchthroughClient::SendPing::TestMode tm)
 {
 	switch (tm)
 	{


### PR DESCRIPTION
Fixes #21 to get rid of warnings when compiling on Linux.
