### PR TITLE
Fix 3 memory leaks in AutoPatcher/ApplyPatch.cpp

### DIFF
--- a/DependentExtensions/Autopatcher/ApplyPatch.cpp
+++ b/DependentExtensions/Autopatcher/ApplyPatch.cpp
@@ -297,6 +297,10 @@ int TestPatchInMemory(int argc,char *argv[])
 	fclose(newFile);
 	fclose(oldFile);
 
+	delete[] patch;
+	delete[] old;
+	delete[] _new;
+
 	return res;
 }
 


### PR DESCRIPTION
This commit fixes three memory leaks in the AutoPatcher code:

ApplyPatch.cpp:288: patch = new char[patchSize];
ApplyPatch.cpp:289: old = new char[oldSize];
ApplyPatch.cpp:191: _new = new char[*newSize+1];

These buffers aren't deleted when returning from
  int TestPatchInMemory(int argc, char*argv[])
at line 300 of the original sources, so (patchSize + oldSize + newSize + 1)
bytes of memory are leaked.
