### PR TITLE
Fix undefined behaviour in DebugTools.cpp

### DIFF
--- a/Samples/Tests/DebugTools.cpp
+++ b/Samples/Tests/DebugTools.cpp
@@ -8,6 +8,9 @@
  *
  */
 
+#include <iostream>
+#include <limits>
+
 #include "DebugTools.h"
 
 DebugTools::DebugTools(void)
@@ -20,15 +23,12 @@ DebugTools::~DebugTools(void)
 
 void DebugTools::ShowError(RakString errorString,bool pause, unsigned int lineNum,const char *fileName)
 {
-
-	char pauseChar;
-	fflush(stdin);
-
 	printf("%s\nFile:%s \nLine: %i\n",errorString.C_String(),fileName,lineNum);
 
 	if (pause)
 	{
 		printf("Press enter to continue \n");
-		pauseChar=getchar();
+		std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+		char pauseChar = std::cin.get();
 	}
 }


### PR DESCRIPTION
This commit replaces a call to fflush(stdin) with std::cin.ignore() since
calling fflush on an input stream is undefined behaviour and should be
avoided.
