### PR TITLE
Revert patch causing timestamps to be received with the incorrect endianness

### DIFF
--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -3796,7 +3796,6 @@ void RakPeer::ShiftIncomingTimestamp( unsigned char *data, const SystemAddress &
 #endif
 
 	RakNet::BitStream timeBS( data, sizeof(RakNet::Time), false);
-        timeBS.EndianSwapBytes(0,sizeof(RakNet::Time));
 	RakNet::Time encodedTimestamp;
 	timeBS.Read(encodedTimestamp);
 


### PR DESCRIPTION
Reverting https://github.com/larku/RakNet/pull/15

My assumption is the original author was writing the timestamp with the wrong endianness in the first place, which is easily done when not using bitstreams (see http://www.jenkinssoftware.com/raknet/manual/creatingpackets.html). The original patch causes the endianness to be inverted twice when using bitstreams, breaking reception of these timestamps.
