### PR TITLE
Stop out of bounds memory read

### DIFF
--- a/Source/RakNetSocket2_Berkley.cpp
+++ b/Source/RakNetSocket2_Berkley.cpp
@@ -322,9 +322,15 @@ RNS2BindResult RNS2_Berkley::BindSharedIPV4And6( RNS2_BerkleyBindParameters *bin
 		ret = bind__(rns2Socket, aip->ai_addr, (int) aip->ai_addrlen );
 		if (ret>=0)
 		{
-			// Is this valid?
-			memcpy(&boundAddress.address.addr6, aip->ai_addr, sizeof(boundAddress.address.addr6));
-
+ 			if (aip->ai_family == AF_INET)
+ 			{
+ 				memcpy(&boundAddress.address.addr4, aip->ai_addr, sizeof(sockaddr_in));
+ 			}
+ 			else
+ 			{
+ 				memcpy(&boundAddress.address.addr6, aip->ai_addr, sizeof(sockaddr_in6));
+ 			}
+			
 			freeaddrinfo(servinfo); // free the linked-list
 
 			SetSocketOptions();


### PR DESCRIPTION
The code sometimes copies an IPv4 address with the size of an IPv6 address.